### PR TITLE
Add dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu:20.04
+RUN apt-get update && apt-get install -y python3 python3-pip iptables
+WORKDIR /app
+COPY project-memoria-detector.py requirements.txt ./
+RUN pip3 install -r requirements.txt
+ENTRYPOINT [ "python3", "/app/project-memoria-detector.py" ]
+CMD ["-h"]


### PR DESCRIPTION
I was running in to [this](https://github.com/secdev/scapy/commit/46fa40fde4049ad7770481f8806c59640df24059) bug when running the script on my machine so I built a Dockerfile for it. Here's an example of how to use it:

```bash
docker build -t "project-memoria-detector" .

docker run --rm --cap-add=NET_ADMIN --network host project-memoria-detector -i wlp0s20f3 192.168.11.1
```

I haven't done of testing with this but I'm creating a PR since others may find it useful.